### PR TITLE
Initialize WiFi stack and reconnection logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(PicoSwitchWGA
 
 add_subdirectory(bluepad32/src/components/bluepad32 libbluepad32)
 
-pico_enable_stdio_usb(PicoSwitchWGA 0)
+pico_enable_stdio_usb(PicoSwitchWGA 1)
 pico_enable_stdio_uart(PicoSwitchWGA 0)
 
 # create map/bin/hex/uf2 file in addition to ELF.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include_directories(PicoSwitchWGA src)
 
 target_link_libraries(PicoSwitchWGA
     pico_stdlib
-    pico_cyw43_arch_none
+    pico_cyw43_arch_lwip_threadsafe_background
     pico_btstack_classic
     pico_btstack_cyw43
     bluepad32

--- a/src/main.c
+++ b/src/main.c
@@ -16,19 +16,38 @@
 // Defined in my_platform.c
 struct uni_platform *get_my_platform(void);
 
+// WiFi credentials; replace with real values
+#define WIFI_SSID "YOUR_WIFI_SSID"
+#define WIFI_PASSWORD "YOUR_WIFI_PASSWORD"
+
+static repeating_timer_t wifi_timer;
+
+static bool wifi_reconnect_callback(repeating_timer_t *rt) {
+        int status = cyw43_tcpip_link_status(&cyw43_state, CYW43_ITF_STA);
+        if (status != CYW43_LINK_UP) {
+                cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 0);
+                logi("WiFi reconnecting...\n");
+                cyw43_arch_wifi_connect_async(WIFI_SSID, WIFI_PASSWORD, CYW43_AUTH_WPA2_AES_PSK);
+        } else {
+                cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
+        }
+        return true;
+}
+
 void bluepad_core_task()
 {
 	// initialize CYW43 driver architecture (will enable BT if/because CYW43_ENABLE_BLUETOOTH == 1)
-	if (cyw43_arch_init()) {
-		loge("failed to initialise cyw43_arch\n");
-		return -1;
-	}
+        if (cyw43_arch_init()) {
+                loge("failed to initialise cyw43_arch\n");
+                return;
+        }
 
-	// Turn-on LED. Turn it off once init is done.
-	cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
+        cyw43_arch_enable_sta_mode();
+        cyw43_arch_wifi_connect_async(WIFI_SSID, WIFI_PASSWORD, CYW43_AUTH_WPA2_AES_PSK);
+        add_repeating_timer_ms(5000, wifi_reconnect_callback, NULL, &wifi_timer);
 
-	// Must be called before uni_main()
-	uni_platform_set_custom(get_my_platform());
+        // Must be called before uni_main()
+        uni_platform_set_custom(get_my_platform());
 
 	// Initialize BP32
 	uni_init(0, NULL);


### PR DESCRIPTION
## Summary
- enable lwIP thread-safe background networking
- initialize WiFi, enable STA mode and reconnect with status LED

## Testing
- `make build` *(fails: SDK location was not specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2783d7bc832eba77c7a6b96aeaa4